### PR TITLE
Fix asr calculation and adding a new extreme calculation method

### DIFF
--- a/libs/prayertime/prayer.h
+++ b/libs/prayertime/prayer.h
@@ -126,7 +126,8 @@ extern "C" {
       11: Half of the Night: Fajr Ishaa if invalid
       12: Minutes from Shorooq/Maghrib: Fajr Ishaa Always (e.g. Maghrib=Ishaa)
       13: Minutes from Shorooq/Maghrib: Fajr Ishaa If invalid
-
+      14: Nearest Good Day: Fajr Ishaa if either is invalid
+      15: Angle based: Fajr Ishaa if invalid
     */
 
 


### PR DESCRIPTION
Fixes calculation of Asr time for locations in the southern hemishphere. Also forces re-calculation for extreme latitudes and adds an angle based method for re-calculating extreme locations.

These fixes are based on direct feedback from users in these areas who have provided prayer times from local mosques (which are very similar to times found on islamicfinder.org).
