### PR TITLE
make libitl.pc install path relative to build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ configure_file("libitl.pc.in" "libitl.pc" @ONLY)
 install( FILES ${HEADER_FILES} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/itl" )
 install( TARGETS itl DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 install( TARGETS itlShared DESTINATION ${CMAKE_INSTALL_LIBDIR} )
-install(FILES "libitl.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
+install( FILES ${CMAKE_BINARY_DIR}/libitl.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/ )
 
 # Specify executables
 add_executable( demo_hijri hijri/demo_hijri.c )


### PR DESCRIPTION
This patch makes libitl.pc's path during the installation phase be relative to the build directory instead of the source directory. 

This is necessary for NixOS builds - while building in a build directory, it is unable to reference back to the source directory for the original file as said file should be in the build directory.

Signed-off-by: Amy Parker <amy@amyip.net>